### PR TITLE
Expanded property and Msv class names to human-friendly names

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
       <h2>Timing Object</h2>
 
       <p>
-        A <dfn>timing object</dfn> is conceptualized as a point moving along an infinite axis. The value of the timing object is essentially the position, velocity and acceleration of the point, at a specific moment in time. So, essentially, the timing object is a representation of linear motion in real time. The timing object uses a <a>media state vector</a> to represent the initial conditions of the current motion. This is known as the internal <dfn>vector</dfn> of the timing object. This <a>vector</a> is used by the <dfn>query</dfn> operation to calculate fresh <a>media state vector</a> snapshots, based on timestamps from the system clock. The <dfn>update</dfn> operation allows the timing object to be updated, by modifying the internal <a>vector</a>. The timing object supports any motion that can be expressed in terms of a <a>media state vector</a>. This way, the timing object is expressive enough to implement clocks, stop-watches and a variety of media controllers (at least the temporal aspects of media control). A <dfn>range</dfn> may be specified for the position of the timing object.
+        A <dfn>timing object</dfn> is conceptualized as a point moving along an infinite axis. The value of the timing object is essentially the position, velocity and acceleration of the point, at a specific moment in time. So, essentially, the timing object is a representation of linear motion in real time. The timing object uses a <a>state vector</a> to represent the initial conditions of the current motion. This is known as the <dfn>internal vector</dfn> of the timing object. This <a>internal vector</a> is used by the <dfn>query</dfn> operation to calculate fresh <a>state vector</a> snapshots, based on timestamps from the system clock. The <dfn>update</dfn> operation allows the timing object to be updated, by modifying the <a>internal vector</a>. The timing object supports any motion that can be expressed in terms of a <a>state vector</a>. This way, the timing object is expressive enough to implement clocks, stop-watches and a variety of media controllers (at least the temporal aspects of media control). A <dfn>range</dfn> may be specified for the position of the timing object.
       </p>
 
       <p><a title="timing object">Timing objects</a> implement the following interface:</p>
@@ -563,9 +563,9 @@
 
 
         <dt>readonly attribute MediaStateVector vector </dt>
-        <dd>The internal vector of the timing object</dd>
+        <dd>The <a>internal vector</a> of the timing object</dd>
         <dt>readonly attribute MediaStateVector previousVector </dt>
-        <dd>The vector that was replaced by the current internal vector. This may be helpful for computing the nature of the last change, after the fact.</dd>
+        <dd>The vector that was replaced by the current <a>internal vector</a>. This may be helpful for computing the nature of the last change, after the fact.</dd>
 
 
 
@@ -586,7 +586,7 @@
         <!-- Methods -->
 
         <dt>MediaStateVector query ()</dt>
-        <dd>When invoked, the user agent must compute a snapshot from the internal <a>vector</a> and the current local time and return the result. See <a>process query</a> for details.</dd>
+        <dd>When invoked, the user agent must compute a snapshot from the <a>internal vector</a> and the current local time and return the result. See <a>process query</a> for details.</dd>
 
         <dt>void update ()</dt>
         <dd>
@@ -634,7 +634,7 @@
             <tr>
               <td><dfn><code>change</code></dfn></td>
               <td><a><code>Event</code></a></td>
-              <td>The internal <a>vector</a> is changed. Fired after the <code>update()</code> method has returned, or when an update is received from the <a>online timing resource</a>.</td>
+              <td>The <a>internal vector</a> is changed. Fired after the <code>update()</code> method has returned, or when an update is received from the <a>online timing resource</a>.</td>
             </tr>
             <tr>
               <td><dfn><code>readystatechange</code></dfn></td>
@@ -662,15 +662,15 @@
 
 
     <section>
-      <h2>Media State Vector</h2>
+      <h2>State Vector</h2>
 
       <p>
-        A <dfn>media state vector</dfn> represents the classical four-tuple <code>(p,v,a,t)</code> associated with the mathematical description of linear motion under constant acceleration. The elements of this four tuple represent <code>(position, velocity, acceleration, time)</code>. The <a>timing object</a> uses the <a>media state vector</a> for multiple purposes. Internally, the <a>media state vector</a> represents the initial conditions of the current movement. This is known as the <dfn>internal vector</dfn>. The <a>query</a> operation returns a <a>media state vector</a> as snapshot, and the <a>update</a> operation requires a <a>media state vector</a> as parameter. Finally, in the distributed scenario, the <a>media state vector</a> is the unit of distribution.
+        A <dfn>state vector</dfn> represents the classical four-tuple <code>(p,v,a,t)</code> associated with the mathematical description of linear motion under constant acceleration. The elements of this four tuple represent <code>(position, velocity, acceleration, time)</code>. The <a>timing object</a> uses the <a>state vector</a> for multiple purposes. Internally, the <a>state vector</a> represents the initial conditions of the current movement. This is known as the <dfn>internal vector</dfn>. The <a>query</a> operation returns a <a>state vector</a> as snapshot, and the <a>update</a> operation requires a <a>state vector</a> as parameter. Finally, in the distributed scenario, the <a>state vector</a> is the unit of distribution.
       </p>
 
-      <p><a title="media state vector">Media state vectors</a> implement the following interface</p>
+      <p><a title="state vector">State vectors</a> implement the following interface</p>
 
-      <dl title="interface MediaStateVector" class="idl">
+      <dl title="interface StateVector" class="idl">
         <dt>readonly attribute double position</dt>
         <dd>Position on a uni-dimensional axis.</dd>
 
@@ -730,7 +730,7 @@
         </p>
         <ol>
           <li>Let <em>timing</em> be a newly constructed <code><a>timing object</a></code>.</li>
-          <li>Initialize <em>timing</em>'s internal <a>vector</a>. Default is <code>(0.0, 0.0, 0.0, t)</code>, where <code>t</code> is the local timestamp in seconds when the object is created</li> 
+          <li>Initialize <em>timing</em>'s <a>internal vector</a>. Default is <code>(0.0, 0.0, 0.0, t)</code>, where <code>t</code> is the local timestamp in seconds when the object is created</li> 
           <li>Return <em>timing</em>.</li>
         </ol>
         </section>
@@ -742,7 +742,7 @@
         </p>
         <ol>
           <li>Let fresh timestamp <code>t</code> from system clock represent processing time of query.</li>
-          <li>Let <code>(p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current internal <a>vector</a></li>
+          <li>Let <code>(p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current <a>internal vector</a></li>
           <li>Calculate <code> p = p<sub>i</sub> + v<sub>i</sub> (t - t<sub>i</sub>) + 1/2 a<sub>i</sub> (t - t<sub>i</sub>)<sup>2</sup></code></li>
           <li>Calculate <code> v = v<sub>i</sub> + a<sub>i</sub> (t - t<sub>i</sub>)</code></li>
           <li>Calculate <code> a = a<sub>i</sub></code></li>
@@ -757,10 +757,10 @@
         </p>
         <ol>
           <li>Let fresh timestamp <code>t</code> from system clock represent processing time of update.
-          <li>Let <code>vector<sub>i</sub> : (p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current internal <a>vector</a></li>
-          <li>Let <code>vector<sub>j</sub> : (p<sub>j</sub>, v<sub>j</sub>, a<sub>j</sub>, t)</code> represent the new <a>vector</a></li>
+          <li>Let <code>vector<sub>i</sub> : (p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current <a>internal vector</a></li>
+          <li>Let <code>vector<sub>j</sub> : (p<sub>j</sub>, v<sub>j</sub>, a<sub>j</sub>, t)</code> represent the new <a>internal vector</a></li>
           <li>If <code>vector<sub>j</sub></code> is incomplete, calculate missing values by following the approach described in <a>process query</a>.</li>
-          <li>Replace current internal vector with new vector <code>vector<sub>i</sub> = vector<sub>j</sub></code></li>
+          <li>Replace the current <a>internal vector</a> with new vector <code>vector<sub>i</sub> = vector<sub>j</sub></code></li>
           <li><a>Set internal timeout</a> if <a>range</a> is specified for the timing object.</li>
           <li>Fire an event named <code>change</code> at the timing object</li>
         </ol>
@@ -797,7 +797,7 @@
       <p>If an online timing resource is <a title="update">updated</a>, effects must apply equally to all connected timing objects, as quickly as possible.</p>
 
       <p>
-        Update synchronization uses the <a>media state vector</a> as the unit of distribution. Implementation of distributed synchronization implies that local timing objects become local representatives for online timing resources. This has implications for <a title="process update">update processing</a>. Local timing objects will no longer process updates themselves, but simply forward update requests (i.e. the <a>media state vector</a> parameter) across the network to the online timing resource. The algorithm for <a title="process update"> update processing</a> will instead be carried out by the timing service. Effects (i.e. the new <a>media state vector</a>) are multicast by the timing service to all connected timing objects, finally triggering the update event. <a title="process query">Query processing</a> will remain unchanged. Queries are always resolved locally, using the last <a>media state vector</a> received from the server.
+        Update synchronization uses the <a>state vector</a> as the unit of distribution. Implementation of distributed synchronization implies that local timing objects become local representatives for online timing resources. This has implications for <a title="process update">update processing</a>. Local timing objects will no longer process updates themselves, but simply forward update requests (i.e. the <a>state vector</a> parameter) across the network to the online timing resource. The algorithm for <a title="process update"> update processing</a> will instead be carried out by the timing service. Effects (i.e. the new <a>state vector</a>) are multicast by the timing service to all connected timing objects, finally triggering the update event. <a title="process query">Query processing</a> will remain unchanged. Queries are always resolved locally, using the last <a>state vector</a> received from the server.
       </p>
 
       <p>
@@ -812,7 +812,7 @@
         If multiple timing objects (connected to the same online timing resource) are <a title="query">queried</a> at the exact same moment in time, they must ideally provide the same result (i.e. same position, velocity and acceleration). Implementations must approximate this as much as possible.
       </p>
       <p>
-        Clock synchronization among timing service and timing objects is required for <a title="media state vector">media state vectors</a> to resolve to the same position, velocity and acceleration. As synchronized system clocks is not a valid assumption in the Web environment, it follows that clock synchronization must be resolved as part of the communication between timing objects and timing service. To do this, timing objects maintain a software clock that is continuously synchronized with the system clock of the timing service. This is possible by means of periodic measurements of RTT and clock skew. Using this server clock, timing objects can tranform <a title="media state vector">media state vectors</a> with respect to their own local system clock. Clock synchronization is also very fast, stable estimates are reached within fractions of a second. Given a strict client-server architecture, this is the optimal approach.
+        Clock synchronization among timing service and timing objects is required for <a title="state vector">state vectors</a> to resolve to the same position, velocity and acceleration. As synchronized system clocks is not a valid assumption in the Web environment, it follows that clock synchronization must be resolved as part of the communication between timing objects and timing service. To do this, timing objects maintain a software clock that is continuously synchronized with the system clock of the timing service. This is possible by means of periodic measurements of RTT and clock skew. Using this server clock, timing objects can tranform <a title="state vector">state vectors</a> with respect to their own local system clock. Clock synchronization is also very fast, stable estimates are reached within fractions of a second. Given a strict client-server architecture, this is the optimal approach.
       </p>
       <p>
         Implementation relies on open Web sockets connections to minimize latency between timing objects and the timing service. If implemented correctly in both client and server, this approach provides a basis for sub-framerate media synchronization.

--- a/index.html
+++ b/index.html
@@ -562,9 +562,9 @@
         </dd>
 
 
-        <dt>readonly attribute MediaStateVector vector </dt>
+        <dt>readonly attribute StateVector vector </dt>
         <dd>The <a>internal vector</a> of the timing object</dd>
-        <dt>readonly attribute MediaStateVector previousVector </dt>
+        <dt>readonly attribute StateVector previousVector </dt>
         <dd>The vector that was replaced by the current <a>internal vector</a>. This may be helpful for computing the nature of the last change, after the fact.</dd>
 
 
@@ -585,7 +585,7 @@
 
         <!-- Methods -->
 
-        <dt>MediaStateVector query ()</dt>
+        <dt>StateVector query ()</dt>
         <dd>When invoked, the user agent must compute a snapshot from the <a>internal vector</a> and the current local time and return the result. See <a>process query</a> for details.</dd>
 
         <dt>void update ()</dt>
@@ -593,7 +593,7 @@
           When called, the user agent must update the internal <code>vector</code> if the timing object, based on the given <code>newVector</code>. The basic action is <code>vector=newVector</code> and set the timestamp correctly, i,e,. a fresh timestamp from the system clock representing the exact processing time of the update operation. However, the update operation also supports properties of <code>newVector</code> to be <code>undefined</code> or <code>null</code>. This provides a simple mechanism for tying movements together. The idea is to allow one aspect of the movement to be updated while preserving the others. For instance, <code>{position:null, velocity:value, acceleration:null}</code> means <i>update velocity while preserving current position and acceleration</i>. See <a>process update</a> for details.
 
           <dl class="parameters">
-            <dt>optional MediaStateVector newVector</dt>
+            <dt>optional StateVector newVector</dt>
             <dd>The new vector</dd>
             <dt>optional Object options</dt>
             <dd>@@</dd>
@@ -657,7 +657,7 @@
 
 
 
-    <!-- MediaStateVector -->
+    <!-- StateVector -->
 
 
 
@@ -746,7 +746,7 @@
           <li>Calculate <code> p = p<sub>i</sub> + v<sub>i</sub> (t - t<sub>i</sub>) + 1/2 a<sub>i</sub> (t - t<sub>i</sub>)<sup>2</sup></code></li>
           <li>Calculate <code> v = v<sub>i</sub> + a<sub>i</sub> (t - t<sub>i</sub>)</code></li>
           <li>Calculate <code> a = a<sub>i</sub></code></li>
-          <li>Return a new <a>MediaStateVector</a> (<code>p,v,a,t</code>)</li>
+          <li>Return a new <a>StateVector</a> (<code>p,v,a,t</code>)</li>
         </ol>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
       <h2>Timing Object</h2>
 
       <p>
-        A <dfn>timing object</dfn> is conceptualized as a point moving along an infinite axis. The value of the timing object is essentially the position, velocity and acceleration of the point, at a specific moment in time. So, essentially, the timing object is a representation of linear motion in real time. The timing object uses a <a>media state vector</a> to represent the initial conditions of the current motion. This is known as the internal <dfn>vector</dfn> of the timing object. This <a>vector</a> is used by the <dfn>query</dfn> operation to calculate fresh <a>media state vector</a> snapshots, based on timestamps from the system clock. The <dfn>update</dfn> operation allows the timing object to be updated, by modifying the internal <a>vector</a>. The timing object supports any motion that can be expressed in terms of a <a>media state vector</a>. This way, the timing object is expressive enough to implement clocks, stop-watches and a variety of media controllers (at least the temporal aspects of media control). A <dfn>range</dfn> may be specified for the position of the timing object.
+        A <dfn>timing object</dfn> is conceptualized as a point moving along an infinite axis. The value of the timing object is essentially the position, velocity and acceleration of the point, at a specific moment in time. So, essentially, the timing object is a representation of linear motion in real time. The timing object uses a <a>state vector</a> to represent the initial conditions of the current motion. This is known as the <dfn>internal vector</dfn> of the timing object. This <a>internal vector</a> is used by the <dfn>query</dfn> operation to calculate fresh <a>state vector</a> snapshots, based on timestamps from the system clock. The <dfn>update</dfn> operation allows the timing object to be updated, by modifying the <a>internal vector</a>. The timing object supports any motion that can be expressed in terms of a <a>state vector</a>. This way, the timing object is expressive enough to implement clocks, stop-watches and a variety of media controllers (at least the temporal aspects of media control). A <dfn>range</dfn> may be specified for the position of the timing object.
       </p>
 
       <p><a title="timing object">Timing objects</a> implement the following interface:</p>
@@ -563,9 +563,9 @@
 
 
         <dt>readonly attribute MediaStateVector vector </dt>
-        <dd>The internal vector of the timing object</dd>
+        <dd>The <a>internal vector</a> of the timing object</dd>
         <dt>readonly attribute MediaStateVector previousVector </dt>
-        <dd>The vector that was replaced by the current internal vector. This may be helpful for computing the nature of the last change, after the fact.</dd>
+        <dd>The vector that was replaced by the current <a>internal vector</a>. This may be helpful for computing the nature of the last change, after the fact.</dd>
 
 
 
@@ -586,7 +586,7 @@
         <!-- Methods -->
 
         <dt>MediaStateVector query ()</dt>
-        <dd>When invoked, the user agent must compute a snapshot from the internal <a>vector</a> and the current local time and return the result. See <a>process query</a> for details.</dd>
+        <dd>When invoked, the user agent must compute a snapshot from the <a>internal vector</a> and the current local time and return the result. See <a>process query</a> for details.</dd>
 
         <dt>void update ()</dt>
         <dd>
@@ -634,7 +634,7 @@
             <tr>
               <td><dfn><code>change</code></dfn></td>
               <td><a><code>Event</code></a></td>
-              <td>The internal <a>vector</a> is changed. Fired after the <code>update()</code> method has returned, or when an update is received from the <a>online timing resource</a>.</td>
+              <td>The <a>internal vector</a> is changed. Fired after the <code>update()</code> method has returned, or when an update is received from the <a>online timing resource</a>.</td>
             </tr>
             <tr>
               <td><dfn><code>readystatechange</code></dfn></td>
@@ -662,15 +662,15 @@
 
 
     <section>
-      <h2>Media State Vector</h2>
+      <h2>State Vector</h2>
 
       <p>
-        A <dfn>media state vector</dfn> represents the classical four-tuple <code>(p,v,a,t)</code> associated with the mathematical description of linear motion under constant acceleration. The elements of this four tuple represent <code>(position, velocity, acceleration, time)</code>. The <a>timing object</a> uses the <a>media state vector</a> for multiple purposes. Internally, the <a>media state vector</a> represents the initial conditions of the current movement. This is known as the <dfn>internal vector</dfn>. The <a>query</a> operation returns a <a>media state vector</a> as snapshot, and the <a>update</a> operation requires a <a>media state vector</a> as parameter. Finally, in the distributed scenario, the <a>media state vector</a> is the unit of distribution.
+        A <dfn>state vector</dfn> represents the classical four-tuple <code>(p,v,a,t)</code> associated with the mathematical description of linear motion under constant acceleration. The elements of this four tuple represent <code>(position, velocity, acceleration, time)</code>. The <a>timing object</a> uses the <a>state vector</a> for multiple purposes. Internally, the <a>state vector</a> represents the initial conditions of the current movement. This is known as the <dfn>internal vector</dfn>. The <a>query</a> operation returns a <a>state vector</a> as snapshot, and the <a>update</a> operation requires a <a>state vector</a> as parameter. Finally, in the distributed scenario, the <a>state vector</a> is the unit of distribution.
       </p>
 
-      <p><a title="media state vector">Media state vectors</a> implement the following interface</p>
+      <p><a title="state vector">State vectors</a> implement the following interface</p>
 
-      <dl title="interface MediaStateVector" class="idl">
+      <dl title="interface StateVector" class="idl">
         <dt>readonly attribute double position</dt>
         <dd>Position on a uni-dimensional axis.</dd>
 
@@ -730,7 +730,7 @@
         </p>
         <ol>
           <li>Let <em>timing</em> be a newly constructed <code><a>timing object</a></code>.</li>
-          <li>Initialize <em>timing</em>'s internal <a>vector</a>. Default is <code>(0.0, 0.0, 0.0, t)</code>, where <code>t</code> is the local timestamp in seconds when the object is created</li> 
+          <li>Initialize <em>timing</em>'s <a>internal vector</a>. Default is <code>(0.0, 0.0, 0.0, t)</code>, where <code>t</code> is the local timestamp in seconds when the object is created</li> 
           <li>Return <em>timing</em>.</li>
         </ol>
         </section>
@@ -742,7 +742,7 @@
         </p>
         <ol>
           <li>Let fresh timestamp <code>t</code> from system clock represent processing time of query.
-          <li>Let <code>(p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current internal <a>vector</a></li>
+          <li>Let <code>(p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current <a>internal vector</a></li>
           <li>Calculate <code> p = p<sub>i</sub> + v<sub>i</sub> (t - t<sub>i</sub>) + 1/2 a<sub>i</sub> (t - t<sub>i</sub>)<sup>2</sup></code></li>
           <li>Calculate <code> v = v<sub>i</sub> + a<sub>i</sub> (t - t<sub>i</sub>)</code></li>
           <li>Calculate <code> a = a<sub>i</sub></code></li>
@@ -757,10 +757,10 @@
         </p>
         <ol>
           <li>Let fresh timestamp <code>t</code> from system clock represent processing time of update.
-          <li>Let <code>vector<sub>i</sub> : (p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current internal <a>vector</a></li>
-          <li>Let <code>vector<sub>j</sub> : (p<sub>j</sub>, v<sub>j</sub>, a<sub>j</sub>, t)</code> represent the new <a>vector</a></li>
+          <li>Let <code>vector<sub>i</sub> : (p<sub>i</sub>, v<sub>i</sub>, a<sub>i</sub>, t<sub>i</sub>)</code> represent the current <a>internal vector</a></li>
+          <li>Let <code>vector<sub>j</sub> : (p<sub>j</sub>, v<sub>j</sub>, a<sub>j</sub>, t)</code> represent the new <a>internal vector</a></li>
           <li>If <code>vector<sub>j</sub></code> is incomplete, calculate missing values by following the approach described in <a>process query</a>.</li>
-          <li>Replace current internal vector with new vector <code>vector<sub>i</sub> = vector<sub>j</sub></code></li>
+          <li>Replace the current <a>internal vector</a> with new vector <code>vector<sub>i</sub> = vector<sub>j</sub></code></li>
           <li><a>Set internal timeout</a> if <a>range</a> is specified for timing object.</li>
           <li>Fire onchange event</li>
         </ol>
@@ -797,7 +797,7 @@
       <p>If an online timing resource is <a title="update">updated</a>, effects must apply equally to all connected timing objects, as quickly as possible.</p>
 
       <p>
-        Update synchronization uses the <a>media state vector</a> as the unit of distribution. Implementation of distributed synchronization implies that local timing objects become local representatives for online timing resources. This has implications for <a title="process update">update processing</a>. Local timing objects will no longer process updates themselves, but simply forward update requests (i.e. the <a>media state vector</a> parameter) across the network to the online timing resource. The algorithm for <a title="process update"> update processing</a> will instead be carried out by the timing service. Effects (i.e. the new <a>media state vector</a>) are multicast by the timing service to all connected timing objects, finally triggering the update event. <a title="process query">Query processing</a> will remain unchanged. Queries are always resolved locally, using the last <a>media state vector</a> received from the server.
+        Update synchronization uses the <a>state vector</a> as the unit of distribution. Implementation of distributed synchronization implies that local timing objects become local representatives for online timing resources. This has implications for <a title="process update">update processing</a>. Local timing objects will no longer process updates themselves, but simply forward update requests (i.e. the <a>state vector</a> parameter) across the network to the online timing resource. The algorithm for <a title="process update"> update processing</a> will instead be carried out by the timing service. Effects (i.e. the new <a>state vector</a>) are multicast by the timing service to all connected timing objects, finally triggering the update event. <a title="process query">Query processing</a> will remain unchanged. Queries are always resolved locally, using the last <a>state vector</a> received from the server.
       </p>
 
       <p>
@@ -812,7 +812,7 @@
         If multiple timing objects (connected to the same online timing resource) are <a title="query">queried</a> at the exact same moment in time, they must ideally provide the same result (i.e. same position, velocity and acceleration). Implementations must approximate this as much as possible.
       </p>
       <p>
-        Clock synchronization among timing service and timing objects is required for <a title="media state vector">media state vectors</a> to resolve to the same position, velocity and acceleration. As synchronized system clocks is not a valid assumption in the Web environment, it follows that clock synchronization must be resolved as part of the communication between timing objects and timing service. To do this, timing objects maintain a software clock that is continuously synchronized with the system clock of the timing service. This is possible by means of periodic measurements of RTT and clock skew. Using this server clock, timing objects can tranform <a title="media state vector">media state vectors</a> with respect to their own local system clock. Clock synchronization is also very fast, stable estimates are reached within fractions of a second. Given a strict client-server architecture, this is the optimal approach.
+        Clock synchronization among timing service and timing objects is required for <a title="state vector">state vectors</a> to resolve to the same position, velocity and acceleration. As synchronized system clocks is not a valid assumption in the Web environment, it follows that clock synchronization must be resolved as part of the communication between timing objects and timing service. To do this, timing objects maintain a software clock that is continuously synchronized with the system clock of the timing service. This is possible by means of periodic measurements of RTT and clock skew. Using this server clock, timing objects can tranform <a title="state vector">state vectors</a> with respect to their own local system clock. Clock synchronization is also very fast, stable estimates are reached within fractions of a second. Given a strict client-server architecture, this is the optimal approach.
       </p>
       <p>
         Implementation relies on open Web sockets connections to minimize latency between timing objects and the timing service. If implemented correctly in both client and server, this approach provides a basis for sub-framerate media synchronization.

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
         </p>
 
         <p>
-          Linear composition is simply the idea that complex linear media could be built from simpler, independent linear components. This way, the classical benefits of composition as a design principle, i.e., flexibility, reusability, extensibility and mashup-ability, would fully apply to linear media. For example, in the single-device scenario, imagine a linear presentation made from HTML5 video, some timed meta-information, a SMIL component, a WebAnimation, a map with timed georeferenced data, and a timed Twitter widget. Or, in the multi-device scenario, imagine the same components distributed or duplicated across multiple devices. In both cases linear composition requires interoperability of heterogeneous linear components, through precisely coordinated, timed playback. Currently though there is weak support for linear composition, and a main reason for this is that timing control mechanisms are custom and internal to each framework. This central purpose of the timing object is thus to simplify interoperability by providing a common basis for timing control in linear media.
+          Linear composition is simply the idea that complex linear media could be built from simpler, independent linear components. This way, the classical benefits of composition as a design principle, i.e. flexibility, reusability, extensibility and mashup-ability, would fully apply to linear media. For example, in the single-device scenario, imagine a linear presentation made from HTML5 video, some timed meta-information, a SMIL component, a WebAnimation, a map with timed georeferenced data, and a timed Twitter widget. Or, in the multi-device scenario, imagine the same components distributed or duplicated across multiple devices. In both cases linear composition requires interoperability of heterogeneous linear components, through precisely coordinated, timed playback. Currently though there is weak support for linear composition, and a main reason for this is that timing control mechanisms are custom and internal to each framework. This central purpose of the timing object is thus to simplify interoperability by providing a common basis for timing control in linear media.
         </p>
 
         <p>
@@ -524,7 +524,7 @@
       <h2>Timing Object</h2>
 
       <p>
-        A <dfn>timing object</dfn> is conceptualized as a point moving along an infinite axis. The value of the timing object is essentially the position, velocity and acceleration of the point, at a specific moment in time. So, essentially, the timing object is a representation of linear motion in real time. The timing object uses an <a>Msv</a> to represent the initial conditions of the current motion. This is known as the internal <dfn>vector</dfn> of the timing object. This <a>vector</a> is used by the <dfn>query</dfn> operation to calculate fresh <a>Msv</a> snapshots, based on timestamps from the system clock. The <dfn>update</dfn> operation allows the timing object to be updated, by modifying the internal <a>vector</a>. The timing object supports any motion that can be expressed in terms of <a>Msv</a>'s. This way, the timing object is expressive enough to implement clocks, stop-watches and a variety of media controllers (at least the temporal aspects of media control). A <dfn>range</dfn> may be specified for the position of the timing object.
+        A <dfn>timing object</dfn> is conceptualized as a point moving along an infinite axis. The value of the timing object is essentially the position, velocity and acceleration of the point, at a specific moment in time. So, essentially, the timing object is a representation of linear motion in real time. The timing object uses a <a>media state vector</a> to represent the initial conditions of the current motion. This is known as the internal <dfn>vector</dfn> of the timing object. This <a>vector</a> is used by the <dfn>query</dfn> operation to calculate fresh <a>media state vector</a> snapshots, based on timestamps from the system clock. The <dfn>update</dfn> operation allows the timing object to be updated, by modifying the internal <a>vector</a>. The timing object supports any motion that can be expressed in terms of a <a>media state vector</a>. This way, the timing object is expressive enough to implement clocks, stop-watches and a variety of media controllers (at least the temporal aspects of media control). A <dfn>range</dfn> may be specified for the position of the timing object.
       </p>
 
       <p><a title="timing object">Timing objects</a> implement the following interface:</p>
@@ -562,9 +562,9 @@
         </dd>
 
 
-        <dt>readonly attribute Msv vector </dt>
+        <dt>readonly attribute MediaStateVector vector </dt>
         <dd>The internal vector of the timing object</dd>
-        <dt>readonly attribute Msv previousVector </dt>
+        <dt>readonly attribute MediaStateVector previousVector </dt>
         <dd>The vector that was replaced by the current internal vector. This may be helpful for computing the nature of the last change, after the fact.</dd>
 
 
@@ -585,15 +585,15 @@
 
         <!-- Methods -->
 
-        <dt>Msv query ()</dt>
+        <dt>MediaStateVector query ()</dt>
         <dd>When invoked, the user agent must compute a snapshot from the internal <a>vector</a> and the current local time and return the result. See <a>process query</a> for details.</dd>
 
         <dt>void update ()</dt>
         <dd>
-          When called, the user agent must update the internal <code>vector</code> if the timing object, based on the given <code>newVector</code>. The basic action is <code>vector=newVector</code> and set the timestamp correctly, i,e,. a fresh timestamp from the system clock representing the exact processing time of the update operation. However, the update operation also supports properties of <code>newVector</code> to be <code>undefined</code> or <code>null</code>. This provides a simple mechanism for tying movements together. The idea is to allow one aspect of the movement to be updated while preserving the others. For instance, <code>{pos:null, vel:value, acc:null}</code> means <i>update velocity while preserving current position and acceleration</i>. See <a>process update</a> for details.
+          When called, the user agent must update the internal <code>vector</code> if the timing object, based on the given <code>newVector</code>. The basic action is <code>vector=newVector</code> and set the timestamp correctly, i,e,. a fresh timestamp from the system clock representing the exact processing time of the update operation. However, the update operation also supports properties of <code>newVector</code> to be <code>undefined</code> or <code>null</code>. This provides a simple mechanism for tying movements together. The idea is to allow one aspect of the movement to be updated while preserving the others. For instance, <code>{position:null, velocity:value, acceleration:null}</code> means <i>update velocity while preserving current position and acceleration</i>. See <a>process update</a> for details.
 
           <dl class="parameters">
-            <dt>optional Msv newVector</dt>
+            <dt>optional MediaStateVector newVector</dt>
             <dd>The new vector</dd>
             <dt>optional Object options</dt>
             <dd>@@</dd>
@@ -603,14 +603,14 @@
         <dt>boolean isMoving ()</dt>
         <dd>Shorthand utility method. Returns False is both velocity and acceleration are equal to 0.0, else True.</dd>
 
-        <dt>attribute readonly double currentPos</dt>
+        <dt>attribute readonly double currentPosition</dt>
           <dd>
-            Shorthand accessor for current position, equivalent to <code>query().pos</code>
+            Shorthand accessor for current position, equivalent to <code>query().position</code>
           </dd>
-        <dt>attribute readonly double currentVel</dt>
-        <dd>Shorthand accessor for current velocity, equivalent to <code>query().vel</code></dd>
-        <dt>attribute readonly double currentAcc</dt>
-        <dd>Shorthand accessor for current acceleration, equivalent to <code>query().acc</code></dd>
+        <dt>attribute readonly double currentVelocity</dt>
+        <dd>Shorthand accessor for current velocity, equivalent to <code>query().velocity</code></dd>
+        <dt>attribute readonly double currentAcceleration</dt>
+        <dd>Shorthand accessor for current acceleration, equivalent to <code>query().acceleration</code></dd>
 
 
   
@@ -657,31 +657,31 @@
 
 
 
-    <!-- MSV -->
+    <!-- MediaStateVector -->
 
 
 
     <section>
-      <h2>Media State Vector (MSV)</h2>
+      <h2>Media State Vector</h2>
 
       <p>
-        A Media State Vector (<dfn>msv</dfn>) represents the classical four-tuple <code>(p,v,a,t)</code> associated with the mathematical description of linear motion under constant acceleration. The elements of this four tuple represent <code>(position, velocity, acceleration, time)</code>. The <a>timing object</a> uses the <a>msv</a> for multiple purposes. Internally, the <a>msv</a> represents the initial conditions of the current movement. This is known as the <dfn>internal vector</dfn>. The <a>query</a> operation returns a <a>msv</a> as snapshot, and the <a>update</a> operation requires <a>msv</a> as parameter. Finally, in the distributed scenario, the <a>msv</a> is the unit of distribution.
+        A <dfn>media state vector</dfn> represents the classical four-tuple <code>(p,v,a,t)</code> associated with the mathematical description of linear motion under constant acceleration. The elements of this four tuple represent <code>(position, velocity, acceleration, time)</code>. The <a>timing object</a> uses the <a>media state vector</a> for multiple purposes. Internally, the <a>media state vector</a> represents the initial conditions of the current movement. This is known as the <dfn>internal vector</dfn>. The <a>query</a> operation returns a <a>media state vector</a> as snapshot, and the <a>update</a> operation requires a <a>media state vector</a> as parameter. Finally, in the distributed scenario, the <a>media state vector</a> is the unit of distribution.
       </p>
 
-      <p><a title="msv">Media State Vectors</a> implement the following interface</p>
+      <p><a title="media state vector">Media state vectors</a> implement the following interface</p>
 
-      <dl title="interface Msv" class="idl">
-        <dt>readonly attribute double pos</dt>
+      <dl title="interface MediaStateVector" class="idl">
+        <dt>readonly attribute double position</dt>
         <dd>Position on a uni-dimensional axis.</dd>
 
-        <dt>readonly attribute double vel</dt>
+        <dt>readonly attribute double velocity</dt>
         <dd>Velocity along a uni-dimensional axis.</dd>
 
-        <dt>readonly attribute double acc</dt>
+        <dt>readonly attribute double acceleration</dt>
         <dd>Acceleration along a uni-dimensional axis.</dd>
 
-        <dt>readonly attribute double ts</dt>
-        <dd>Timestamp from system clock. The moment in time when <code>pos</code>, <code>vel</code> and <code>acc</code> were|are|will be valid.</dd>
+        <dt>readonly attribute double timestamp</dt>
+        <dd>Timestamp from system clock. The moment in time when <code>position</code>, <code>velocity</code> and <code>acceleration</code> were|are|will be valid.</dd>
       </dl>
     </section>
 
@@ -746,7 +746,7 @@
           <li>Calculate <code> p = p<sub>i</sub> + v<sub>i</sub> (t - t<sub>i</sub>) + 1/2 a<sub>i</sub> (t - t<sub>i</sub>)<sup>2</sup></code></li>
           <li>Calculate <code> v = v<sub>i</sub> + a<sub>i</sub> (t - t<sub>i</sub>)</code></li>
           <li>Calculate <code> a = a<sub>i</sub></code></li>
-          <li>Return <a>Msv</a> (<code>p,v,a,t</code>)</li>
+          <li>Return a new <a>MediaStateVector</a> (<code>p,v,a,t</code>)</li>
         </ol>
         </section>
 
@@ -797,7 +797,7 @@
       <p>If an online timing resource is <a title="update">updated</a>, effects must apply equally to all connected timing objects, as quickly as possible.</p>
 
       <p>
-        Update synchronization uses the <a>Msv</a> as the unit of distribution. Implementation of distributed synchronization implies that local timing objects become local representatives for online timing resources. This has implications for <a title="process update">update processing</a>. Local timing objects will no longer process updates themselves, but simply forward update requests (i.e., <a>Msv</a> parameter) across the network to the online timing resource. The algorithm for <a title="process update"> update processing</a> will instead be carried out by the timing service. Effects (i.e., the new <a>Msv</a>) are multicast by the timing service to all connected timing objects, finally triggering the update event. <a title="process query">Query processing</a> will remain unchanged. Queries are always resolved locally, using the last <a>Msv</a> received from the server.
+        Update synchronization uses the <a>media state vector</a> as the unit of distribution. Implementation of distributed synchronization implies that local timing objects become local representatives for online timing resources. This has implications for <a title="process update">update processing</a>. Local timing objects will no longer process updates themselves, but simply forward update requests (i.e. the <a>media state vector</a> parameter) across the network to the online timing resource. The algorithm for <a title="process update"> update processing</a> will instead be carried out by the timing service. Effects (i.e. the new <a>media state vector</a>) are multicast by the timing service to all connected timing objects, finally triggering the update event. <a title="process query">Query processing</a> will remain unchanged. Queries are always resolved locally, using the last <a>media state vector</a> received from the server.
       </p>
 
       <p>
@@ -809,10 +809,10 @@
     <section>
       <h3> Clock synchronization </h3>
       <p> 
-        If multiple timing objects (connected to the same online timing resource) are <a title="query">queried</a> at the exact same moment in time, they must ideally provide the same result (i.e., same position, velocity and acceleration). Implementations must approximate this as much as possible.
+        If multiple timing objects (connected to the same online timing resource) are <a title="query">queried</a> at the exact same moment in time, they must ideally provide the same result (i.e. same position, velocity and acceleration). Implementations must approximate this as much as possible.
       </p>
       <p>
-        Clock synchronization among timing service and timing objects is required for <a>Msv</a>'s to resolve to the same position, velocity and acceleration. As synchronized system clocks is not a valid assumption in the Web environment, it follows that clock synchronization must be resolved as part of the communication between timing objects and timing service. To do this, timing objects maintain a software clock that is continuously synchronized with the system clock of the timing service. This is possible by means of periodic measurements of RTT and clock skew. Using this server clock, timing objects can tranform <a>Msv</a>'s with respect to their own local system clock. Clock synchronization is also very fast, stable estimates are reached within fractions of a second. Given a strict client-server architecture, this is the optimal approach.
+        Clock synchronization among timing service and timing objects is required for <a title="media state vector">media state vectors</a> to resolve to the same position, velocity and acceleration. As synchronized system clocks is not a valid assumption in the Web environment, it follows that clock synchronization must be resolved as part of the communication between timing objects and timing service. To do this, timing objects maintain a software clock that is continuously synchronized with the system clock of the timing service. This is possible by means of periodic measurements of RTT and clock skew. Using this server clock, timing objects can tranform <a title="media state vector">media state vectors</a> with respect to their own local system clock. Clock synchronization is also very fast, stable estimates are reached within fractions of a second. Given a strict client-server architecture, this is the optimal approach.
       </p>
       <p>
         Implementation relies on open Web sockets connections to minimize latency between timing objects and the timing service. If implemented correctly in both client and server, this approach provides a basis for sub-framerate media synchronization.


### PR DESCRIPTION
It is usually considered good practice to define human-friendly class and
property names in specification and to avoid acronyms when possible.

This update changes "Msv" used as a concept into "media state vector" and
"Msv" used as a class name into "MediaStateVector". Media state vector
properties have also been renamed to "position", "velocity", "acceleration"
and "timestamp" to improve readability.

I also removed commas next to "i.e." in that commit. While I understand
that it's actually correct in American English, all specs I checked do not
use it, and it catches my eye each time. I hid that removal into this commit
in the hope that the change would go unnoticed ;)
