### PR TITLE
Update spec to latest version of ReSpec

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
   <head>
     <title>Timing Object</title>
     <meta charset="utf-8">
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common"
-            async class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c"
+            class="remove" defer></script>
     <script class="remove">
       var respecConfig = {
           specStatus: "CG-DRAFT",
           edDraftURI: "https://webtiming.github.io/timingobject",
-          shortName:  "timing-object",
+          shortName:  "timingobject",
           editors: [
             {
               name:       "Ingar M. Arntzen",
@@ -32,9 +32,9 @@
               mailto: "njaal.borch@motioncorporation.com"
             }
           ],
-          wg:           "Multi-Device Timing Community Group",
-          wgURI:        "https://www.w3.org/community/webtiming/",
-          wgPublicList: "public-webtiming",
+          group: "webtiming",
+          github: "webtiming/timingobject",
+          xref: ['dom', 'webidl', 'html'],
 
           localBiblio:  {
             "LINEARCOMPOSITION": {
@@ -104,10 +104,7 @@
                 }
               ]
             }
-          ],
-
-          issueBase: "https://www.github.com/webtiming/timingobject/issues/",
-          githubAPI: "https://api.github.com/repos/webtiming/timingobject"
+          ]
       };
     </script>
     <style type="text/css">
@@ -145,7 +142,7 @@
         The specification is intended for discussion within the Multi-Device Timing Community Group. Its content does not yet represent the consensus of the Community Group.
       </p>
       <p class="warning">
-        This specification is incomplete. Some procedures are either missing or described as <em>similar to procedures defined in [[HTML5]]</em>. The main goal of this draft is to propose a technical solution, show how it could be integrated in [[HTML5]] and gather feedback from interested parties before dwelving into details.
+        This specification is incomplete. Some procedures are either missing or described as <em>similar to procedures defined in [[HTML]]</em>. The main goal of this draft is to propose a technical solution, show how it could be integrated in [[HTML]] and gather feedback from interested parties before dwelving into details.
       </p>
     </section>
     
@@ -173,7 +170,7 @@
         <h3>Linear composition</h3>
 
         <p>
-          <dfn data-lt="linear composition|linear composability">Linear composition</dfn> or <dfn>temporal composition</dfn> is simply the idea that complex linear media can be built from simpler, independent linear components. Web support for linear composition would imply that classical benefits of composition, i.e. flexibility, reusability, extensibility and mashup-ability, apply to the construction of Web-based linear media. For example, in the single-device scenario, imagine a linear presentation made from HTML5 video, some timed meta-information, a SMIL component, a Web Animation, a map with timed georeferenced data, and a timed Twitter widget. Or, in the multi-device scenario, imagine the same components distributed or duplicated across multiple devices in a room or within a social group. In both cases linear composition requires temporal interoperability among heterogeneous linear components, available through precisely coordinated, timed playback.
+          <dfn data-lt="linear composition|linear composability">Linear composition</dfn> or <dfn class="lint-ignore">temporal composition</dfn> is simply the idea that complex linear media can be built from simpler, independent linear components. Web support for linear composition would imply that classical benefits of composition, i.e. flexibility, reusability, extensibility and mashup-ability, apply to the construction of Web-based linear media. For example, in the single-device scenario, imagine a linear presentation made from HTML video, some timed meta-information, a SMIL component, a Web Animation, a map with timed georeferenced data, and a timed Twitter widget. Or, in the multi-device scenario, imagine the same components distributed or duplicated across multiple devices in a room or within a social group. In both cases linear composition requires temporal interoperability among heterogeneous linear components, available through precisely coordinated, timed playback.
         </p>
         <p>
           Unfortunately, Web support for linear composition is not optimal. Each media framework tends to define its own custom timing control mechanisms, making it difficult to achieve <a>linear composition</a> in practice. The central purpose of the timing object is thus to simplify interoperability by providing a common basis for timed operation and control in linear media.
@@ -191,7 +188,7 @@
         </p>
         <ol>
           <li>
-            <b>provide a unifying API for timed operation and temporal control</b> that timed components can integrate with. This would include timing sensitive Web applications in general, as well as existing frameworks for timed media &mdash; such as <a>media elements</a> in [[HTML5]], Web Animations [[WEB-ANIMATIONS-1]], Web Audio API [[WEBAUDIO]] and SMIL Timing [[SMIL3]]. The API must support highly precise timing and be expressive enough to support control primitives appropriate for a wide range of media types and applications.
+            <b>provide a unifying API for timed operation and temporal control</b> that timed components can integrate with. This would include timing sensitive Web applications in general, as well as existing frameworks for timed media &mdash; such as <a>media elements</a> in [[HTML]], Web Animations [[WEB-ANIMATIONS-1]], Web Audio API [[WEBAUDIO]] and SMIL Timing [[SMIL3]]. The API must support highly precise timing and be expressive enough to support control primitives appropriate for a wide range of media types and applications.
           </li>
           <li> 
             <b>encapsulate complexity of distributed time synchronization</b>, thereby allowing integrating frameworks to be included in precisely timed multi-device operation. In particular, by providing the same API for local and online timing resources, timed components may be used in single-device and multi-device scenarios, without modification. 
@@ -212,7 +209,7 @@
         </p>
 
         <p class="note">
-          This specification describes the integration of timing objects with HTML5 Media elements and text tracks. Integration with other frameworks for timed operation, such as Web Animation, SMIL, and WebAudio will be covered separately.
+          This specification describes the integration of timing objects with HTML Media elements and text tracks. Integration with other frameworks for timed operation, such as Web Animation, SMIL, and WebAudio will be covered separately.
         </p>
       </section>
 
@@ -357,53 +354,33 @@
       <h2>Terminology</h2>
 
       <p>
-        The following terms, procedures and interfaces are defined in [[!HTML5]]:
+        This specification uses the following terms and procedures defined in &mdash;but not exported by&mdash; [[!HTML]]:
       </p>
       <ul>
-        <li><dfn data-lt="event handler|event handlers"><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handler</a></dfn></li>
-        <li><dfn data-lt="event handler event type|event handler event types"><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type">event handler event type</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">queue a task</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#fire-a-simple-event">fire a simple event</a></dfn></li>
-        <li><dfn data-lt="media element|media elements"><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#media-element">media element</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#media-timeline">media timeline</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#effective-playback-rate">effective playback rate</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#current-media-controller">current media controller</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#slaved-media-elements">slaved media elements</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#report-the-controller-state">report the controller state</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#seek">seek</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#media-data">media data</a></dfn></li>
-        <li><dfn data-lt="text tracks"><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track">text track</a></dfn></li>
-        <li><dfn data-lt="text track cue|text track cues"><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-cue">text track cue</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-kind">text track kind</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-label">text track label</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-language">text track language</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-mode">text track mode</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-hidden">text track hidden</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-loaded">text track loaded</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-readiness-state">text track readiness state</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#text-track-list-of-cue">text track list of cues</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#list-of-text-tracks">list of text tracks</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#list-of-newly-introduced-cues">list of newly introduced cues</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#current-playback-position">current playback position</a></dfn></li>
-        <li><dfn><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#time-marches-on">time marches on</a></dfn></li>
-        <li><dfn><code><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a></code></dfn></li>
-        <li><dfn><code><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#htmlmediaelement">HTMLMediaElement</a></code></dfn></li>
-        <li><dfn><code><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#mediacontroller">MediaController</a></code></dfn></li>
-        <li><dfn><code><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#texttrack">TextTrack</a></code></dfn></li>
-        <li><dfn><code><a href="https://www.w3.org/html/wg/drafts/html/master/webappapis.html#texttrackkind">TextTrackKind</a></code></dfn></li>
+        <li><dfn data-lt="media element|media elements"><a href="https://html.spec.whatwg.org/multipage/media.html#media-element">media element</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">effective playback rate</a></dfn></li>
+        <li><dfn data-lt="text tracks"><a href="https://html.spec.whatwg.org/multipage/media.html#text-track">text track</a></dfn></li>
+        <li><dfn data-lt="text track cue|text track cues"><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-cue">text track cue</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-kind">text track kind</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-label">text track label</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-mode">text track mode</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-hidden">text track hidden</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-loaded">text track loaded</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-readiness-state">text track readiness state</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#text-track-list-of-cues">text track list of cues</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#current-playback-position">current playback position</a></dfn></li>
+        <li><dfn><a href="https://html.spec.whatwg.org/multipage/media.html#time-marches-on">time marches on</a></dfn></li>
       </ul>
 
       <p>
-        The following interfaces are defined in [[!DOM]]:
+        This specification was also developed to align with the concept of media controller, which used to be defined in [[!HTML5]], and currently depends on the following superseded terms and procedures:
       </p>
       <ul>
-        <li><dfn><code><a href="https://www.w3.org/TR/dom/#event">Event</a></code></dfn></li>
-        <li><dfn><code><a href="https://www.w3.org/TR/dom/#interface-eventtarget">EventTarget</a></code></dfn></li>
+        <li><dfn><a href="https://www.w3.org/TR/2018/SPSD-html5-20180327/embedded-content-0.html#current-media-controller">current media controller</a></dfn></li>
+        <li><dfn><a href="https://www.w3.org/TR/2018/SPSD-html5-20180327/embedded-content-0.html#slaved-media-elements">slaved media elements</a></dfn></li>
+        <li><dfn><a href="https://www.w3.org/TR/2018/SPSD-html5-20180327/embedded-content-0.html#report-the-controller-state">report the controller state</a></dfn></li>
+        <li><dfn><code><a href="https://www.w3.org/TR/2018/SPSD-html5-20180327/embedded-content-0.html#mediacontroller">MediaController</a></code></dfn></li>
       </ul>
-
-      <p>
-        The <code><a href="https://dev.w3.org/html5/spec/webappapis.html#eventhandler">EventHandler</a></code> interface represents a callback used for <a>event handlers</a> as defined in [[!HTML5]].
-      </p>
 
       <p>
         The <dfn>internal clock</dfn> is based on the precise, high-resolution, and monotonic clock defined in [[!HR-TIME]], with values representing <i>seconds</i>, not milliseconds. In essence, the <a>internal clock</a> is defined as <code>performance.now()/1000.0</code>. All time values refered to by the timing object specification are expressed in <i>seconds</i>. This includes timestamps in <a>state vectors</a> as well as <a>skew</a> estimates communicated from <a>timing provider objects</a> to <a>timing objects</a>.
@@ -626,7 +603,7 @@
                       attribute EventHandler      ontimeupdate;
                       attribute EventHandler      onerror;
           TimingStateVector query ();
-          Promise&lt;void&gt; update (optional TimingStateVectorUpdate newVector = {});
+          Promise&lt;undefined&gt; update (optional TimingStateVectorUpdate newVector = {});
         };
       </pre>
 
@@ -666,7 +643,7 @@
             </ol>
           </li>
           <li>Let <var>timing</var>'s <a>state</a> be <code>open</code>.</li>
-          <li><a>Queue a task</a> to <a>fire a simple event</a> named <code>readystatechange</code> at <var>timing</var>.</li>
+          <li><a>Queue a task</a> to <a>fire an event</a> named <code>readystatechange</code> at <var>timing</var>.</li>
           <li>Return <var>timing</var>.</li>
         </ol>
  
@@ -687,8 +664,8 @@
             When an update to the <code>readyState</code> property is observed, run the following substeps:
             <ol>
               <li>If the transition from the current <a>state</a> of <var>timing</var> to the new value is in the list of <a>allowed state transitions</a>, let <var>timing</var>'s <a>state</a> be the new value. Otherwise, let <var>timing</var>'s <code>state</code> be <code>closed</code> and <a>stop observing</a> <var>provider</var>.</li>
-              <li>If the <code>error</code> property of <var>provider</var> is not null, <a>queue a task</a> to <a>fire a simple event</a> named <code>error</code> at <var>timing</var>.</li>
-              <li><a>Queue a task</a> to <a>fire a simple event</a> named <code>readystatechange</code> at <var>timing</var>.</li>
+              <li>If the <code>error</code> property of <var>provider</var> is not null, <a>queue a task</a> to <a>fire an event</a> named <code>error</code> at <var>timing</var>.</li>
+              <li><a>Queue a task</a> to <a>fire an event</a> named <code>readystatechange</code> at <var>timing</var>.</li>
             </ol>
           </li>
           <li>
@@ -715,7 +692,7 @@
           When a <a>user agent</a> is required to <dfn>stop observing</dfn> an object, it MUST stop any monitoring that was running on that object in the background.
         </p>
         <p class="issue">
-          This <a data-lt="observe">observing</a> mechanism is meant to emulate the <code>Object.observe</code> method that is being proposed in EcmaScript 7 to simplify the <code><a>TimingProvider</a></code> interface and requirements set on a <a>timing resource provider</a>, as well as to work around the fact that <code><a>TimingProvider</a></code> cannot inherit <code><a>EventTarget</a></code>. The Multi-Device Timing Community Group welcomes feedback as to whether this approach is doable in practice.
+          This <a data-lt="observe">observing</a> mechanism is meant to emulate the <code>Object.observe</code> method that is being proposed in EcmaScript 7 to simplify the <code><a>TimingProvider</a></code> interface and requirements set on a <a>timing resource provider</a>, as well as to work around the fact that <code><a>TimingProvider</a></code> cannot inherit {{EventTarget}}. The Multi-Device Timing Community Group welcomes feedback as to whether this approach is doable in practice.
         </p>
       </section>
 
@@ -747,7 +724,7 @@
               <li>Let <var>vector</var> be newly created <code>TimingStateVectorUpdate</code> that from three-tuple (<var>p<sub>modified</sub></var>, 0, 0).</li>
               <li>Let <var>timing</var>'s <a>internal vector</a> be <var>vector</var>.</li>
               <li>Clear the <a>current range timeout</a> of <var>timing</var>.</li>
-              <li><a>Queue a task</a> to <a>fire a simple event</a> named <code>change</code> at the <var>timing</var>.</li>
+              <li><a>Queue a task</a> to <a>fire an event</a> named <code>change</code> at the <var>timing</var>.</li>
               <li>Let <var>result</var> be result from invoking <a data-link-for="TimingObject">query</a> method on <var>timing</var> (recursively).</li>
             </ol>
           </li>
@@ -801,7 +778,7 @@
           <li>Let <var>vector</var> be a newly created <code><a>TimingStateVector</a></code> that represents the four-tuple (<var>p</var>, <var>v</var>, <var>a</var>, <var>t<sub>now</sub></var>).</li>
           <li>Set the <a>internal vector</a> of <var>timing</var> to <var>vector</var>.</li>
           <li><a data-lt="set the internal timeout">Set the internal timeout</a> of <var>timing</var>.</li>
-          <li><a>Queue a task</a> to <a>fire a simple event</a> named <code>change</code> at <var>timing</var>.</li>
+          <li><a>Queue a task</a> to <a>fire an event</a> named <code>change</code> at <var>timing</var>.</li>
           <li>Resolve <var>promise</var>.</li>
         </ol>
       </section>
@@ -849,7 +826,7 @@
           <li>Let <var>newVector</var> be the new vector.</li>
           <li>Let <var>timing</var>'s <a>internal vector</a> be <var>newVector</var>.</li>
           <li><a data-lt="set the internal timeout">Set the internal timeout</a> of <var>timing</var>.</li>
-          <li><a>Queue a task</a> to <a>fire a simple event</a> named <code>change</code> at <var>timing</var>.</li>
+          <li><a>Queue a task</a> to <a>fire an event</a> named <code>change</code> at <var>timing</var>.</li>
         </ol>
       </section>
 
@@ -969,17 +946,17 @@
  
             <tr>
               <td><dfn><code>onchange</code></dfn></td>
-              <td><dfn><code>change</code></dfn></td>
+              <td><code>change</code></td>
               <td>The <a>internal vector</a> is changed. Fired after the <code>update()</code> method has returned, or when an update is received from the <a>external timing resource</a>.</td>
             </tr>
             <tr>
               <td><dfn><code>onreadystatechange</code></dfn></td>
-              <td><dfn><code>readystatechange</code></dfn></td>
+              <td><code>readystatechange</code></td>
               <td>The <code>readyState</code> attribute changed.<br/></td>
             </tr>
             <tr>
               <td><dfn><code>ontimeupdate</code></dfn></td>
-              <td><dfn><code>timeupdate</code></dfn></td>
+              <td><code>timeupdate</code></td>
               <td>Fires periodically with fixed frequency 5Hz, except when timing object is paused. This is intended as a shorthand alternative for setting up a polling-loop with setInterval, or as an emulation of the pulse-based timing model that programmers are currently used to.</td>
             </tr>
             <tr>
@@ -1032,7 +1009,7 @@
           readonly    attribute unrestricted double endPosition;
           readonly    attribute DOMString         readyState;
           readonly    attribute unrestricted double skew;
-          Promise&lt;void&gt; update (optional TimingStateVectorUpdate newVector = {});
+          Promise&lt;undefined&gt; update (optional TimingStateVectorUpdate newVector = {});
         };
       </pre>
 
@@ -1190,7 +1167,7 @@
       </p>
 
       <p class="note">
-        If this specification progresses along the standardisation track, this section should be merged in a future version of [[!HTML5]].
+        If this specification progresses along the standardisation track, this section should be merged in a future version of [[!HTML]].
       </p>
 
       <section class="informative">
@@ -1378,13 +1355,13 @@
           As opposed to a <a>text track</a>, a <a>timing text track</a> is not and cannot be associated with a <a>media element</a>.
         </p>
         <p class="issue">
-          Is inheriting from <a>TextTrack</a> as proposed above the right approach? An alternative approach would be to extend <a>TextTrack</a> as done for the <a>HTMLMediaElement</a>. The problem with this appraoch is that <a>TextTrack</a> does not expose a constructor, so the only way to create a <a>timing text track</a> would be to add an <code>addTextTrack</code> method to the <a>timing object</a> (similar to the one on <a>HTMLMediaElement</a>). However, this is undesireable, as we would like to maintain a clean separation between <a>timing object</a> and objects that take direction from it. For instance, a clear separation ensures the flexibility to dynamically switch <a>timing object</a> for the <a>timing text track</a>. 
+          Is inheriting from {{TextTrack}} as proposed above the right approach? An alternative approach would be to extend {{TextTrack}} as done for the {{HTMLMediaElement}}. The problem with this appraoch is that {{TextTrack}} does not expose a constructor, so the only way to create a <a>timing text track</a> would be to add an <code>addTextTrack</code> method to the <a>timing object</a> (similar to the one on {{HTMLMediaElement}}). However, this is undesireable, as we would like to maintain a clean separation between <a>timing object</a> and objects that take direction from it. For instance, a clear separation ensures the flexibility to dynamically switch <a>timing object</a> for the <a>timing text track</a>. 
         </p>
         <p class="issue">
-          Note also that the <a>TextTrack</a> design bear witness of close integration with <a>media elements</a>. For example, as the <a>media element</a> must provide UI support for <a>text track</a> visualization, it requires meta information such as track type (kind) and language. However, this meta information may quickly become irrelevant in a context where programmers are making custom timed presentations from application-specific data formats. Furthermore, as the programming of timed presentation is made very easy and flexible using the <a>timing object</a> combined with a general purpose <a>sequencing</a> mechanism, programmers will be much less dependent on the limited UI support for subtitles and captions, that is currently provided by <a>media elements</a>. In this perspective it seems odd to insist that all <a>timing text tracks</a> must be of a specific kind and declare a language. 
+          Note also that the {{TextTrack}} design bear witness of close integration with <a>media elements</a>. For example, as the <a>media element</a> must provide UI support for <a>text track</a> visualization, it requires meta information such as track type (kind) and language. However, this meta information may quickly become irrelevant in a context where programmers are making custom timed presentations from application-specific data formats. Furthermore, as the programming of timed presentation is made very easy and flexible using the <a>timing object</a> combined with a general purpose <a>sequencing</a> mechanism, programmers will be much less dependent on the limited UI support for subtitles and captions, that is currently provided by <a>media elements</a>. In this perspective it seems odd to insist that all <a>timing text tracks</a> must be of a specific kind and declare a language. 
         </p>
         <p class="issue">
-          A <a>media element</a> acts as <a>sequencer</a> for a list of <a>text tracks</a>. It is not clear that <a>timing text tracks</a> similarly need to be managed within a container. If such a container object is deemed necessary (e.g. for consistency with existing standards), such a container object must be defined in this document, say a <dfn>Timing Track</dfn>. The <a>sequencing</a> logic (<a>track marches on</a>) would then be provided by that container object rather than by <a>timing text tracks</a> individually.         
+          A <a>media element</a> acts as <a>sequencer</a> for a list of <a>text tracks</a>. It is not clear that <a>timing text tracks</a> similarly need to be managed within a container. If such a container object is deemed necessary (e.g. for consistency with existing standards), such a container object must be defined in this document, say a <strong>Timing Track</strong>. The <a>sequencing</a> logic (<a>track marches on</a>) would then be provided by that container object rather than by <a>timing text tracks</a> individually.
         </p>
         <p class="issue">
           There is a tradeoff with respect to how much we want <a>timing text tracks</a> to divert from regular <a>text tracks</a>. Keeping it true to its origins may be awkward in some respects. Taking it too far away may be confusing, possibly suggesting that a clean sheets approach with a new sequencer object might be preferable. Note also that programmers may use regular <a>text tracks</a> with a <a>media element</a>, a then let the <a>media element</a> be directed by a <a>timing object</a>.


### PR DESCRIPTION
The spec used an outdated version of ReSpec. This update bumps the version and refreshes cross-references accordingly.

This update also switches most HTML references to the HTML spec, with the exception of the references to media controller that continue to target the superseded HTML5 specification. The terminology still contains the concepts that are defined in but not exported by HTML.