### PR TITLE
Add discontinued note to Status of this Document section

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,39 +72,7 @@
               title: "Open-source sequencer library",
               href: "https://github.com/webtiming/sequencer"
             }
-          },
-          otherLinks: [
-            {
-              key: "Version history",
-              data: [
-                {
-                  value: "GitHub webtiming/timingobject/commits",
-                  href: "https://github.com/webtiming/timingobject/commits/"
-                }
-              ]
-            },
-            {
-              key: "Participate",
-              data: [
-                {
-                  value: "GitHub webtiming/timingobject",
-                  href: "https://github.com/webtiming/timingobject/"
-                },
-                {
-                  value: "File an issue",
-                  href: "https://github.com/webtiming/timingobject/issues/new"
-                },
-                {
-                  value: "Open issues",
-                  href: "https://github.com/webtiming/timingobject/issues/"
-                },
-                {
-                  value: "Mailing-list (public-webtiming@w3.org)",
-                  href: "https://lists.w3.org/Archives/Public/public-webtiming/"
-                }
-              ]
-            }
-          ]
+          }
       };
     </script>
     <style type="text/css">
@@ -138,12 +106,14 @@
     <!-- STATUS OF DOCUMENT -->
 
     <section id="sotd">
-      <p>
-        The specification is intended for discussion within the Multi-Device Timing Community Group. Its content does not yet represent the consensus of the Community Group.
-      </p>
-      <p class="warning">
-        This specification is incomplete. Some procedures are either missing or described as <em>similar to procedures defined in [[HTML]]</em>. The main goal of this draft is to propose a technical solution, show how it could be integrated in [[HTML]] and gather feedback from interested parties before dwelving into details.
-      </p>
+      <div class="advisement">
+        <p>
+          This specification is incomplete. Some procedures are either missing or described as <em>similar to procedures defined in [[HTML]]</em>. The main goal of this draft is to propose a technical solution and show how it could be integrated in [[HTML]].
+        </p>
+        <p>
+          <strong>Work on this document has been discontinued</strong>. This document is provided as-is in the hope that it may prove a useful basis for renewed discussions on a timing model for the Web in the future. Interested parties are encouraged to reach out to the <a href="https://www.w3.org/groups/ig/me/">Media and Entertainment Interest Group</a> for coordination, through its <a href="mailto:public-web-and-tv@w3.org">public-web-and-tv@w3.org</a> mailing-list (<a href="https://lists.w3.org/Archives/Public/public-web-and-tv/">archives</a>).
+        </p>
+      </div>
     </section>
     
 


### PR DESCRIPTION
Given the imminent closure of the Multi-Device Timing CG, the note encourages interested parties to reach out to the Media & Entertainment IG for future coordination.

The update also drops links from the front matter that ReSpec now already generates on its own to avoid duplication.